### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,6 +9,11 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engineStrict": true,
   "scripts": {
     "lint": "balena-lint src test",
-    "lint:fix": "balena-lint --fix src test",
+    "lint-fix": "balena-lint --fix src test",
     "build": "tsc --pretty --project ./tsconfig.dist.json",
     "test": "mocha --config test/.mocha.yml",
     "pretest": "npm run build",
@@ -23,7 +23,7 @@
     "url": "https://github.com/balena-io-modules/typed-error.git"
   },
   "devDependencies": {
-    "@balena/lint": "^6.2.2",
+    "@balena/lint": "^9.3.13",
     "@types/bluebird": "^3.5.38",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",

--- a/src/typed-error.ts
+++ b/src/typed-error.ts
@@ -18,7 +18,7 @@ if (Error.captureStackTrace != null) {
 export class TypedError extends Error {
 	public name: string;
 	public message: string;
-	public stack: string = '';
+	public stack = '';
 
 	constructor(err: Error | string = '') {
 		super();

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,4 +1,4 @@
-import * as Promise from 'bluebird';
+import * as Bluebird from 'bluebird';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
@@ -48,9 +48,9 @@ describe('typescript', () => {
 	});
 
 	describe('Bluebird try/catch', () => {
-		it('instanceof', () => {
-			expect(
-				Promise.try(() => {
+		it('instanceof', async () => {
+			await expect(
+				Bluebird.try(() => {
 					throw new MyError();
 				})
 					.return(false)
@@ -59,10 +59,10 @@ describe('typescript', () => {
 			).to.eventually.equal(true);
 		});
 
-		it('name', () => {
+		it('name', async () => {
 			const MyErrorName = (e: Error) => e.name === 'MyError';
-			expect(
-				Promise.try(() => {
+			await expect(
+				Bluebird.try(() => {
 					throw new MyError();
 				})
 					.return(false)
@@ -71,11 +71,11 @@ describe('typescript', () => {
 			).to.eventually.equal(true);
 		});
 
-		it('constructor.name', () => {
+		it('constructor.name', async () => {
 			const MyErrorConstructorName = (e: Error) =>
 				e.constructor.name === 'MyError';
-			expect(
-				Promise.try(() => {
+			await expect(
+				Bluebird.try(() => {
 					throw new MyError();
 				})
 					.return(false)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,4 +23,3 @@
 		"node_modules"
 	]
 }
-


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch